### PR TITLE
fix: trim diff before converting to json

### DIFF
--- a/src/components/DiffForm/index.jsx
+++ b/src/components/DiffForm/index.jsx
@@ -19,9 +19,10 @@ const convertToJson = line => {
 }
 
 const DiffResults = ({ diff }) => {
-  const [expected, actual] = diff.split("\n").map((line) => line.startsWith('-') 
-    ? convertToJson(line.substring(1)) 
-    : convertToJson(line.substring(1))
+  const [expected, actual] = diff
+      .trim()
+      .split("\n")
+      .map((line) => convertToJson(line.substring(1))
   );
 
   const styles = {


### PR DESCRIPTION
### Change
* trim diff before parsing

### Why?
* before having a space at the end of an input would crash the app

### Testing
* failing example first
* fixed example second


https://github.com/user-attachments/assets/872b1a0b-6b65-4eca-8660-70f11d43c838

